### PR TITLE
Enable cross platform compilation of the solution.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ FakesAssemblies/
 # DNX-based projects have a project.lock.json file. This should not be checked-in during development
 project.lock.json
 .vscode
+.idea 

--- a/targetframework.props
+++ b/targetframework.props
@@ -1,0 +1,10 @@
+<Project>
+    <PropertyGroup Condition="! $(OS.Contains('win')) AND '$(TargetFramework)'== 'net461'">
+        <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.6.1/1.0.1/lib/net461/</FrameworkPathOverride>
+        <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
+    </PropertyGroup>
+    <ItemGroup Condition="! $(OS.Contains('win')) AND '$(TargetFramework)'== 'net461'">
+        <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6.1"  Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+    </ItemGroup>
+</Project>
+

--- a/test/Steeltoe.Common.Autofac.Test/Steeltoe.Common.Autofac.Test.csproj
+++ b/test/Steeltoe.Common.Autofac.Test/Steeltoe.Common.Autofac.Test.csproj
@@ -6,6 +6,14 @@
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup Condition="! $(OS.Contains('win')) AND '$(TargetFramework)'== 'net461'">
+    <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.6.1/1.0.1/lib/net461/</FrameworkPathOverride>
+    <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+  <ItemGroup Condition="! $(OS.Contains('win')) AND '$(TargetFramework)'== 'net461'">
+    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6.1"  Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/test/Steeltoe.Common.Http.Test/Steeltoe.Common.Http.Test.csproj
+++ b/test/Steeltoe.Common.Http.Test/Steeltoe.Common.Http.Test.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">

--- a/test/Steeltoe.Common.Test/Steeltoe.Common.Test.csproj
+++ b/test/Steeltoe.Common.Test/Steeltoe.Common.Test.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
+  
+  <Import Project="..\..\targetframework.props" />
 
   <ItemGroup>
     <None Update="xunit.runner.json">


### PR DESCRIPTION
Without a targeting pack running dotnet build on a mac/ubuntu will fail with a "Reference assemblies were not found".Adding these targeting pack will allow happy roundtripping between windows and mac or ubuntu. See https://github.com/dotnet/sdk/issues/335 for more details